### PR TITLE
Added Skip and Take feature 

### DIFF
--- a/SqlQueryBuilder.Test/SelectQueryBuilderTest.cs
+++ b/SqlQueryBuilder.Test/SelectQueryBuilderTest.cs
@@ -37,18 +37,42 @@ namespace SqlQueryBuilder.Test
         public void SelectFrom_POCO_With_Skip_Take_ValidQuery()
         {
             var isValid = GetBuilder().From<Car>()
-                .Join<Car, CarMaker>(car => car.CarMakerId, maker => maker.Id)
                 .SelectAll<Car>()
-                .Where(c => c.Compare<CarMaker>(maker => maker.Name).With(Operators.EQ, "@brand"))
-                .OrderBy<CarMaker>(maker => maker.FoundationDate, desc: true)
-                .SkipTake(10, 10)
+                .OrderBy<Car>(car => car.ModelYear)
+                .Skip(10).Take(10)
                 .TryBuild(out var query);
 
             Assert.True(isValid, "The query should be valid");
 
-            var expectedQuery = $"SELECT [Car].* FROM [Car] JOIN [CarMaker] ON [Car].[CarMakerId] = [CarMaker].[Id] "
-                + "WHERE (([CarMaker].[Name]) = (@brand)) ORDER BY [CarMaker].[FoundationDate] DESC OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY ";
+            var expectedQuery = $"SELECT [Car].* FROM [Car] ORDER BY [Car].[ModelYear] OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY ";
             Assert.True(CompareQueries(expectedQuery, query));
+        }
+
+        [Fact]
+        public void SelectFrom_POCO_With_Just_Skip_ValidQuery()
+        {
+            var isValid = GetBuilder().From<Car>()
+                .SelectAll<Car>()
+                .OrderBy<Car>(car => car.ModelYear)
+                .Skip(10)
+                .TryBuild(out var query);
+
+            Assert.True(isValid, "The query should be valid");
+
+            var expectedQuery = $"SELECT [Car].* FROM [Car] ORDER BY [Car].[ModelYear] OFFSET 10 ROWS ";
+            Assert.True(CompareQueries(expectedQuery, query));
+        }
+
+        [Fact]
+        public void SelectFrom_POCO_With_Just_Take_ValidQuery()
+        {
+            var isValid = GetBuilder().From<Car>()
+                .SelectAll<Car>()
+                .OrderBy<Car>(car => car.ModelYear)
+                .Take(10)
+                .TryBuild(out var query);
+
+            Assert.False(isValid, "The query should not be valid");
         }
 
         [Theory]

--- a/SqlQueryBuilder.Test/SelectQueryBuilderTest.cs
+++ b/SqlQueryBuilder.Test/SelectQueryBuilderTest.cs
@@ -34,7 +34,7 @@ namespace SqlQueryBuilder.Test
         }
 
         [Fact]
-        public void SelectFrom_POCO_With_Skip_Take_ValidQuery()
+        public void SelectFrom_POCOWithSkipTake_ValidQuery()
         {
             var isValid = GetBuilder().From<Car>()
                 .SelectAll<Car>()
@@ -49,7 +49,7 @@ namespace SqlQueryBuilder.Test
         }
 
         [Fact]
-        public void SelectFrom_POCO_With_Just_Skip_ValidQuery()
+        public void SelectFrom_POCOWithJustSkip_ValidQuery()
         {
             var isValid = GetBuilder().From<Car>()
                 .SelectAll<Car>()
@@ -64,7 +64,7 @@ namespace SqlQueryBuilder.Test
         }
 
         [Fact]
-        public void SelectFrom_POCO_With_Just_Take_ValidQuery()
+        public void SelectFrom_POCOWithJustTake_InvalidQuery()
         {
             var isValid = GetBuilder().From<Car>()
                 .SelectAll<Car>()

--- a/SqlQueryBuilder/Select/IQueryBuilderOrderBy.cs
+++ b/SqlQueryBuilder/Select/IQueryBuilderOrderBy.cs
@@ -6,5 +6,6 @@ namespace SqlQueryBuilder.Select
     public interface IQueryBuilderOrderBy: IBuildQuery
     {
         IQueryBuilderOrderBy OrderBy<T>(Expression<Func<T, object>> lambda, bool desc = false, string tableNameAs = null);
+        IQueryBuilderOrderBy SkipTake(int skip, int take);
     }
 }

--- a/SqlQueryBuilder/Select/IQueryBuilderOrderBy.cs
+++ b/SqlQueryBuilder/Select/IQueryBuilderOrderBy.cs
@@ -3,9 +3,10 @@ using System.Linq.Expressions;
 
 namespace SqlQueryBuilder.Select
 {
-    public interface IQueryBuilderOrderBy: IBuildQuery
+    public interface IQueryBuilderOrderBy : IBuildQuery
     {
         IQueryBuilderOrderBy OrderBy<T>(Expression<Func<T, object>> lambda, bool desc = false, string tableNameAs = null);
-        IQueryBuilderOrderBy SkipTake(int skip, int take);
+        IQueryBuilderOrderBy Skip(int skip);
+        IQueryBuilderOrderBy Take(int take);
     }
 }

--- a/SqlQueryBuilder/Select/SelectQueryBuilder.cs
+++ b/SqlQueryBuilder/Select/SelectQueryBuilder.cs
@@ -137,8 +137,7 @@ namespace SqlQueryBuilder.Select
 
         public IQueryBuilderOrderBy SkipTake(int skip, int take) => SkipIfError(() =>
         {
-            SkipTakeClauses.Add(skip);
-            SkipTakeClauses.Add(take);
+            SkipTakeClauses.AddRange(new List<int>() { skip, take });
         });
 
         public bool TryBuild(out string query)

--- a/SqlQueryBuilder/SqlTranslator.cs
+++ b/SqlQueryBuilder/SqlTranslator.cs
@@ -18,7 +18,7 @@ namespace SqlQueryBuilder
                 HasError = true;
                 return false;
             }
-
+                
             Tables.Add(alias, type);
             return true;
         }
@@ -34,10 +34,7 @@ namespace SqlQueryBuilder
             });
 
             if (kv.Key != null)
-            {
-                var sql = $"[{kv.Key}].{(col == "*" ? "*" : $"[{col}]")}";
-                return sql;
-            }
+                return $"[{kv.Key}].{(col == "*" ? "*" : $"[{col}]")}";
             else
             {
                 HasError = true;

--- a/SqlQueryBuilder/SqlTranslator.cs
+++ b/SqlQueryBuilder/SqlTranslator.cs
@@ -18,7 +18,7 @@ namespace SqlQueryBuilder
                 HasError = true;
                 return false;
             }
-                
+
             Tables.Add(alias, type);
             return true;
         }
@@ -34,7 +34,10 @@ namespace SqlQueryBuilder
             });
 
             if (kv.Key != null)
-                return $"[{kv.Key}].{(col == "*" ? "*" : $"[{col}]")}";
+            {
+                var sql = $"[{kv.Key}].{(col == "*" ? "*" : $"[{col}]")}";
+                return sql;
+            }
             else
             {
                 HasError = true;


### PR DESCRIPTION
After order by, `take` and `skip` can be added now to generate t-sql like this.

`ORDER BY SOME_COLUMN
OFFSET 10 ROWS       -- To skip 10 rows`
`FETCH NEXT 10 ROWS ONLY;  -- take 10 rows`.

